### PR TITLE
docs: remove repeated article footer

### DIFF
--- a/apps/docs/src/components/docs/docs-article-layout.tsx
+++ b/apps/docs/src/components/docs/docs-article-layout.tsx
@@ -11,33 +11,6 @@ import { DocsToc } from "./docs-toc";
 import { PageActions } from "./page-actions";
 import { WasThisHelpful } from "./was-this-helpful";
 
-const footerColumns = [
-  {
-    label: "Get started",
-    links: [
-      { label: "Integrations overview", href: "/integrations" },
-      { label: "Connecting integrations", href: "/integrations/connect" },
-      { label: "Accounting", href: "/integrations/accounting" },
-    ],
-  },
-  {
-    label: "Usage data",
-    links: [
-      { label: "Direct provider APIs", href: "/integrations/usage/direct-provider-apis" },
-      { label: "Instrumentation SDK", href: "/integrations/usage/instrumentation-sdk" },
-      { label: "Observability", href: "/integrations/usage/observability" },
-    ],
-  },
-  {
-    label: "Organization data",
-    links: [
-      { label: "Google Workspace", href: "/integrations/identity/google-workspace" },
-      { label: "Microsoft 365", href: "/integrations/identity/microsoft-365" },
-      { label: "HRIS overview", href: "/integrations/hris" },
-    ],
-  },
-];
-
 export function DocsArticleLayout({
   children,
   page,
@@ -94,25 +67,6 @@ export function DocsArticleLayout({
           ) : null}
           <WasThisHelpful slug={page.slug} />
           <ArticlePager prev={prev} next={next} />
-          <section className="docs-home__footer docs-article__footer" aria-labelledby="docs-article-footer">
-            <h2 className="sr-only" id="docs-article-footer">
-              More resources
-            </h2>
-            <div className="docs-footer-grid">
-              {footerColumns.map((col) => (
-                <div className="docs-footer-col" key={col.label}>
-                  <h3>{col.label}</h3>
-                  <ul>
-                    {col.links.map((link) => (
-                      <li key={link.href}>
-                        <Link href={link.href}>{link.label}</Link>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </section>
         </article>
         <aside className="docs-right-rail" aria-label="Page tools">
           <section className="docs-toc" aria-label="On this page">

--- a/apps/docs/src/styles/globals.css
+++ b/apps/docs/src/styles/globals.css
@@ -535,55 +535,10 @@ pre {
   color: var(--docs-text-soft);
 }
 
-.docs-home__footer {
-  margin-top: 1rem;
-  padding-top: 2rem;
-  border-top: 1px solid var(--docs-border);
-}
-
-.docs-footer-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 2rem;
-}
-
-.docs-footer-col h3 {
-  margin: 0 0 0.75rem;
-  color: var(--docs-text-soft);
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.docs-footer-col ul {
-  display: grid;
-  gap: 0.4rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.docs-footer-col a {
-  color: var(--docs-text-muted);
-  font-size: 0.92rem;
-  text-decoration: none;
-  transition: color 160ms ease;
-}
-
-.docs-footer-col a:hover {
-  color: var(--docs-text);
-}
-
 @media (max-width: 900px) {
   .docs-card-grid--four,
   .docs-card-grid--three {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .docs-footer-grid {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
   }
 }
 
@@ -1274,10 +1229,6 @@ pre {
 
 .docs-pager__spacer {
   display: block;
-}
-
-.docs-article__footer {
-  margin-top: 2.5rem;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- Remove the repeated More resources footer from docs article pages
- Delete the unused footer grid styles
- Keep page-specific next steps, helpfulness feedback, and previous/next navigation

## Verification
- pnpm --filter @doow/docs check:content
- pnpm --filter @doow/docs build
- pnpm build